### PR TITLE
SW-80 [LN] 닉네임 중복 체크 API 개발

### DIFF
--- a/src/services/users/application/service.test.ts
+++ b/src/services/users/application/service.test.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserRepository } from '../infrastructure/repository';
 import { UserService } from './service';
 import { dataSource } from '../../../libs/orm';
+import { plainToClass } from '../../../test';
+import { Profile, User } from '../domain/model';
 
 describe('UserService 테스트', () => {
   let userService: UserService;
@@ -38,5 +40,48 @@ describe('UserService 테스트', () => {
     expect(userRepositorySaveSpy.mock.calls[0][0]).toEqual([result]);
 
     expect(userService).toBeDefined();
+  });
+
+  describe('nickname duplicated check 테스트', () => {
+    test('이미 사용중인 닉네임이면 true 를 반환한다.', async () => {
+      const user = plainToClass(User, {
+        career: 1,
+        email: 'email@test.com',
+        id: 'nanoid',
+        introduction: 'link-gather creator',
+        job: 'Developer',
+        nickname: 'windy',
+        password: expect.not.stringMatching('qhupr22qp3ir23qrn2-23rnj1p'),
+        profileImage: 'image url',
+        provider: 'link-gather',
+        profiles: [
+          plainToClass(Profile, {
+            career: 1,
+            id: 'nanoid',
+            introduction: 'link-gather creator',
+            job: 'Developer',
+            stacks: ['node.js', 'typescript', 'react.js'],
+            urls: ['https://github.com/changchanghwang'],
+          }),
+        ],
+        stacks: ['node.js', 'typescript', 'react.js'],
+        urls: ['https://github.com/changchanghwang'],
+      });
+      const userRepositoryFindSpy = jest.spyOn(userRepository, 'find').mockResolvedValue([user]);
+
+      const result = await userService.isNicknameDuplicated({ nickname: 'windy' });
+
+      expect(userRepositoryFindSpy).toHaveBeenCalledWith({ nickname: 'windy' });
+      expect(result).toBe(true);
+    });
+
+    test('사용 가능한 닉네임이면 false 를 반환한다.', async () => {
+      const userRepositoryFindSpy = jest.spyOn(userRepository, 'find').mockResolvedValue([]);
+
+      const result = await userService.isNicknameDuplicated({ nickname: 'windy' });
+
+      expect(userRepositoryFindSpy).toHaveBeenCalledWith({ nickname: 'windy' });
+      expect(result).toBe(false);
+    });
   });
 });

--- a/src/services/users/application/service.ts
+++ b/src/services/users/application/service.ts
@@ -27,4 +27,10 @@ export class UserService {
   async list({ email, profiles }: { email?: string; profiles?: { jobs: JobType[] } }) {
     return this.userRepository.find({ email, profiles });
   }
+
+  async isNicknameDuplicated({ nickname }: { nickname: string }) {
+    const [user] = await this.userRepository.find({ nickname });
+
+    return !!user;
+  }
 }

--- a/src/services/users/dto/index.ts
+++ b/src/services/users/dto/index.ts
@@ -1,1 +1,2 @@
+export * from './nickname-check';
 export * from './post-dto';

--- a/src/services/users/dto/nickname-check/get-dto.ts
+++ b/src/services/users/dto/nickname-check/get-dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class nicknameCheckQueryDto {
+  @ApiProperty({ example: 'windy', description: '사용자 닉네임', required: true })
+  @IsString()
+  @IsNotEmpty()
+  nickname!: string;
+}

--- a/src/services/users/dto/nickname-check/index.ts
+++ b/src/services/users/dto/nickname-check/index.ts
@@ -1,0 +1,1 @@
+export * from './get-dto';

--- a/src/services/users/infrastructure/repository.ts
+++ b/src/services/users/infrastructure/repository.ts
@@ -9,7 +9,7 @@ export class UserRepository extends Repository<User, User['id']> {
   entityClass = User;
 
   async find(
-    conditions: { email?: string; profiles?: { jobs?: JobType[] } },
+    conditions: { email?: string; profiles?: { jobs?: JobType[] }; nickname?: string },
     options?: PaginationOption,
     order?: FindOrder,
   ): Promise<User[]> {
@@ -17,6 +17,7 @@ export class UserRepository extends Repository<User, User['id']> {
       where: {
         ...stripUndefined({
           email: conditions.email,
+          nickname: conditions.nickname,
           profiles: {
             job: In(conditions.profiles?.jobs),
           },

--- a/src/services/users/presentation/controller.ts
+++ b/src/services/users/presentation/controller.ts
@@ -11,7 +11,7 @@ import {
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { UserService } from '../application/service';
 import type { JobType } from '../domain/model';
-import type { CreateDto } from '../dto';
+import { CreateDto, nicknameCheckQueryDto } from '../dto';
 
 @Controller('users')
 @ApiTags('User')
@@ -38,7 +38,7 @@ export class UserController {
     summary: '닉네임 중복 체크 API',
     description: '사용 불가능한 닉네임일 경우 true, 사용 가능한 닉네임일 경우 false 를 반환한다.',
   })
-  isNicknameDuplicated(@Query('nickname') nickname: string): Promise<boolean> {
+  isNicknameDuplicated(@Query() { nickname }: nicknameCheckQueryDto): Promise<boolean> {
     return this.userService.isNicknameDuplicated({ nickname });
   }
 }

--- a/src/services/users/presentation/controller.ts
+++ b/src/services/users/presentation/controller.ts
@@ -38,7 +38,8 @@ export class UserController {
     summary: '닉네임 중복 체크 API',
     description: '사용 불가능한 닉네임일 경우 true, 사용 가능한 닉네임일 경우 false 를 반환한다.',
   })
-  isNicknameDuplicated(@Query() { nickname }: nicknameCheckQueryDto): Promise<boolean> {
+  isNicknameDuplicated(@Query() query: nicknameCheckQueryDto): Promise<boolean> {
+    const { nickname } = query;
     return this.userService.isNicknameDuplicated({ nickname });
   }
 }

--- a/src/services/users/presentation/controller.ts
+++ b/src/services/users/presentation/controller.ts
@@ -32,4 +32,13 @@ export class UserController {
     const profiles = users.flatMap((user) => user.profiles);
     return profiles;
   }
+
+  @Get('/nickname-check')
+  @ApiOperation({
+    summary: '닉네임 중복 체크 API',
+    description: '사용 불가능한 닉네임일 경우 true, 사용 가능한 닉네임일 경우 false 를 반환한다.',
+  })
+  isNicknameDuplicated(@Query('nickname') nickname: string): Promise<boolean> {
+    return this.userService.isNicknameDuplicated({ nickname });
+  }
 }


### PR DESCRIPTION
### 개발사항
- 닉네임 중복 체크 API 개발 (`GET http://127.0.0.1:3000/users/nickname-check?nickname={nickname}`)
- 테스트 코드 작성

### 결과
- 중복된 닉네임이 있으면 true 반환
<img width="685" alt="스크린샷 2023-03-15 오후 10 31 01" src="https://user-images.githubusercontent.com/63342911/225334477-1eb0c0d6-6553-41c2-86b1-c92d0495cfa5.png">

- 중복된 닉네임이 없으면 false 반환
<img width="701" alt="스크린샷 2023-03-15 오후 10 31 06" src="https://user-images.githubusercontent.com/63342911/225334390-d38e9961-8075-4378-b8a1-451f60c07242.png">


### 추가
- 해당 API 를 권한 없이 호출해도 되는가에 대해 고민해보다가 다른 사이트를 몇 개 찾아봤는데요.
어떤 곳에서는 권한없이 포스트맨으로도 호출할 수 있고 어떤 곳은 토큰(?) 이 필요해서 저희는 어떤 식으로 할건지 정해야할 것 같아요.
근데 이메일은 아니고 닉네임이라 외부에서 호출해도 괜찮을 것 같긴해요. 찾아본 사이트랑 정보 공유합니다.
찾아본 사이트들은 닉네임이 아닌 이메일(또는 아이디) 중복 체크에 관한 거에요.

<details>
<summary>깃허브 (무슨 토큰 필요함)</summary>
<div markdown="1">
<img width="1498" alt="스크린샷 2023-03-15 오후 10 09 11" src="https://user-images.githubusercontent.com/63342911/225332914-95bd9cae-d74e-43e7-bd13-263f9d6c9e16.png">
</div>
</details>

<details>
<summary>사람인 (그냥 호출 가능)</summary>
<div markdown="1">
<img width="1500" alt="스크린샷 2023-03-15 오후 10 09 51" src="https://user-images.githubusercontent.com/63342911/225333263-91c21f76-2947-4942-8b84-0a5184e5dc2b.png">
</div>
</details>

<details>
<summary>구글 (알아볼 수 없음)</summary>
<div markdown="1">
<img width="1417" alt="스크린샷 2023-03-15 오후 10 11 06" src="https://user-images.githubusercontent.com/63342911/225333521-2cc889d3-eb3a-420f-ae49-ba2d89908112.png">
</div>
</details>

<details>
<summary>원티드 (그냥 호출 가능)</summary>
<div markdown="1">
<img width="1287" alt="스크린샷 2023-03-15 오후 10 10 07" src="https://user-images.githubusercontent.com/63342911/225333655-4a8df198-e7c6-4c47-91fa-c8d3f184b709.png">
</div>
</details>