### PR TITLE
SW-108 [LN] 유저 self API 개발

### DIFF
--- a/src/libs/auth/guard.test.ts
+++ b/src/libs/auth/guard.test.ts
@@ -142,6 +142,10 @@ describe('auth guard test', () => {
     mockContext.switchToHttp().getRequest.mockReturnValue({
       signedCookies: {},
     });
-    expect(await authGuard.canActivate(mockContext)).toBe(false);
+    try {
+      await authGuard.canActivate(mockContext);
+    } catch (err) {
+      expect(err).toEqual(unauthorized('Authentication failed.', { errorMessage: '권한 인증에 실패했습니다.' }));
+    }
   });
 });

--- a/src/libs/auth/guard.ts
+++ b/src/libs/auth/guard.ts
@@ -47,6 +47,7 @@ export class AuthGuard implements CanActivate {
         throw err;
       }
     }
-    return false;
+
+    throw unauthorized('Authentication failed.', { errorMessage: '권한 인증에 실패했습니다.' });
   }
 }

--- a/src/services/users/application/service.ts
+++ b/src/services/users/application/service.ts
@@ -89,4 +89,8 @@ export class UserService {
 
     return { accessToken, refreshToken, user };
   }
+
+  async retrieve({ id }: { id: string }) {
+    return this.userRepository.findOneOrFail(id);
+  }
 }

--- a/src/services/users/dto/index.ts
+++ b/src/services/users/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './nickname-check';
+export * from './self';
 export * from './sign-in';
 export * from './sign-up';

--- a/src/services/users/dto/self/get-dto.ts
+++ b/src/services/users/dto/self/get-dto.ts
@@ -1,0 +1,51 @@
+import { IsDate, IsEmail, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ProviderType, providerType } from '../../domain/model';
+
+export class RetrieveResponseDto {
+  @ApiProperty({ example: 'a1b2c3d4e5', description: '유저 id', required: true })
+  @IsNotEmpty()
+  @IsString()
+  id!: string;
+
+  @ApiProperty({ example: 'test@test.com', description: '이메일', required: true })
+  @IsNotEmpty()
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty({ example: 'nickname', description: '닉네임', required: true })
+  @IsNotEmpty()
+  @IsString()
+  nickname!: string;
+
+  @ApiProperty({ example: 'kakao', description: '회원가입 정보 제공자', required: true, enum: providerType })
+  @IsNotEmpty()
+  @IsIn(providerType)
+  provider!: ProviderType;
+
+  @ApiProperty({ example: 'windy', description: '유저 프로필 이미지', required: true })
+  @IsNotEmpty()
+  @IsString()
+  profileImage!: string;
+
+  @ApiProperty({ example: '2023-04-10', description: '닉네임 변경 일자 (3개월마다 변경 가능)' })
+  @IsDate()
+  @IsOptional()
+  nicknameUpdatedOn?: CalendarDate;
+
+  constructor(args: {
+    id: string;
+    email: string;
+    nickname: string;
+    provider: ProviderType;
+    profileImage: string;
+    nicknameUpdatedOn?: CalendarDate;
+  }) {
+    this.id = args.id;
+    this.email = args.email;
+    this.nickname = args.nickname;
+    this.provider = args.provider;
+    this.profileImage = args.profileImage;
+    this.nicknameUpdatedOn = args.nicknameUpdatedOn;
+  }
+}

--- a/src/services/users/dto/self/index.ts
+++ b/src/services/users/dto/self/index.ts
@@ -1,0 +1,1 @@
+export * from './get-dto';

--- a/src/services/users/presentation/controller.test.ts
+++ b/src/services/users/presentation/controller.test.ts
@@ -8,6 +8,7 @@ import { UserRepository } from '../infrastructure/repository';
 import { dataSource } from '../../../libs/orm';
 import { plainToClass } from '../../../libs/test';
 import { User } from '../domain/model';
+import { AuthService } from '../../auth/application/service';
 
 jest.mock('../application/service');
 describe('UserController test', () => {
@@ -18,6 +19,7 @@ describe('UserController test', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
       providers: [
+        AuthService,
         UserService,
         UserRepository,
         JwtService,

--- a/src/services/users/presentation/controller.ts
+++ b/src/services/users/presentation/controller.ts
@@ -6,7 +6,9 @@ import {
   Injectable,
   Post,
   Query,
+  Req,
   Res,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
@@ -19,8 +21,10 @@ import {
   NicknameCheckQueryDto,
   NicknameCheckResponseDto,
   SignInResponseDto,
+  RetrieveResponseDto,
 } from '../dto';
 import { badRequest } from '../../../libs/exception';
+import { AuthGuard } from '../../../libs/auth/guard';
 
 @Controller('users')
 @ApiTags('User')
@@ -89,6 +93,20 @@ export class UserController {
     const isDuplicated = await this.userService.isNicknameDuplicated({ nickname });
 
     const data = new NicknameCheckResponseDto({ isDuplicated });
+    return { data };
+  }
+
+  @Get('/self')
+  @UseGuards(AuthGuard)
+  @ApiOperation({
+    summary: '사용자 자신 정보 조회 API',
+    description: '로그인한 사용자 자신의 정보를 반환한다.',
+  })
+  async retrieve(@Req() req: Request): Result<RetrieveResponseDto> {
+    const { user: actor } = req.state;
+    const user = await this.userService.retrieve({ id: actor.id });
+
+    const data = new RetrieveResponseDto(user);
     return { data };
   }
 }


### PR DESCRIPTION
### 개발사항
- 자기 자신의 정보를 가져오는 self API 구축
- auth guard canActivate 에서 `return false` -> `throw unauthorized (401)` 로 응답하도록 수정


### 이슈링크
- https://linkgather.atlassian.net/jira/software/c/projects/SW/issues/SW-108


### 결과
<img width="841" alt="스크린샷 2023-06-11 오후 5 38 35" src="https://github.com/Link-Gather/link-gather-nest/assets/63342911/5ea9efab-14f2-4bfc-9d17-5981fddf286b">