### PR TITLE
SW-115 [LN] 프로젝트 목록 API 쿼리빌더로 변경

### DIFF
--- a/src/services/profiles/domain/model.ts
+++ b/src/services/profiles/domain/model.ts
@@ -29,7 +29,7 @@ export class Profile extends Aggregate {
   @Column('simple-array')
   urls!: string[];
 
-  @Column('simple-array')
+  @Column('simple-json')
   stacks!: number[];
 
   @Column()

--- a/src/services/projects/application/service.ts
+++ b/src/services/projects/application/service.ts
@@ -26,19 +26,12 @@ export class ProjectService {
         },
         args.order,
       ),
-      this.projectRepository.count(
-        {
-          stacks: args.stacks,
-          purpose: args.purpose,
-          job: args.job,
-          status: args.status,
-        },
-        {
-          limit: Number(args.limit),
-          page: Number(args.page),
-        },
-        args.order,
-      ),
+      this.projectRepository.count({
+        stacks: args.stacks,
+        purpose: args.purpose,
+        job: args.job,
+        status: args.status,
+      }),
     ]);
 
     return { projects, count };

--- a/src/services/projects/domain/model.ts
+++ b/src/services/projects/domain/model.ts
@@ -51,7 +51,7 @@ export class Project extends Aggregate {
   @Column()
   period!: number;
 
-  @Column('simple-array', { nullable: true })
+  @Column('simple-json', { nullable: true })
   stacks?: number[];
 
   @Column()

--- a/src/services/projects/infrastructure/repository.ts
+++ b/src/services/projects/infrastructure/repository.ts
@@ -74,7 +74,7 @@ export class ProjectRepository extends Repository<Project, Project['id']> {
       queryBuilder.andWhere(
         new Brackets((qb) => {
           conditions.stacks!.forEach((stack) => {
-            // NOTE: 직무끼리는 OR 연산
+            // NOTE: stacks 끼리는 OR 연산
             qb.orWhere(
               new Brackets((qb) => {
                 qb.orWhere(`JSON_CONTAINS(project.stacks, '[${stack}]')`);

--- a/src/services/projects/infrastructure/repository.ts
+++ b/src/services/projects/infrastructure/repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Raw } from 'typeorm';
+import { Brackets } from 'typeorm';
 import { FindOrder, PaginationOption, convertOptions, In } from '../../../libs/orm';
 import { Repository } from '../../../libs/ddd';
 import { Project, PurposeType, OrderType, StatusType } from '../domain/model';
@@ -27,46 +27,79 @@ export class ProjectRepository extends Repository<Project, Project['id']> {
     options?: PaginationOption,
     order?: OrderType,
   ): Promise<Project[]> {
+    const { skip, take } = convertOptions(options);
+    const queryBuilder = this.getQuery(conditions);
+
+    if (order) {
+      const orderBy = getOrderOption(order);
+
+      Object.entries(orderBy.order).forEach(([key, value]) => {
+        queryBuilder.addOrderBy(`project.${key}`, value);
+      });
+    }
+
+    const projects = await queryBuilder.skip(skip).take(take).getMany();
     return this.getManager().find(Project, {
       where: {
         ...stripUndefined({
-          stacks: In(conditions.stacks),
-          purpose: conditions.purpose,
-          // TODO: 지금은 선택한 직무를 포함하고 있는 프로젝트 모두 노출이지만 인원이 다 차지 않은 프로젝트만 노출되도록 수정해야 함.
-          recruitMember: conditions.job
-            ? Raw((alias) => `JSON_EXTRACT(${alias}, :job) >= 1`, {
-                job: `$.${conditions.job}`,
-              })
-            : undefined,
-          status: conditions.status,
+          id: In(projects.map((project) => project.id)),
         }),
       },
-      ...convertOptions(options),
       ...getOrderOption(order),
     });
   }
 
-  async count(
-    conditions: { stacks?: string[]; purpose?: PurposeType; job?: JobType; status?: StatusType },
-    options?: PaginationOption,
-    order?: OrderType,
-  ): Promise<number> {
+  async count(conditions: {
+    stacks?: string[];
+    purpose?: PurposeType;
+    job?: JobType;
+    status?: StatusType;
+  }): Promise<number> {
+    if (conditions.stacks || conditions.job) {
+      return this.getQuery(conditions).getCount();
+    }
     return this.getManager().count(Project, {
       where: {
         ...stripUndefined({
-          stacks: In(conditions.stacks),
           purpose: conditions.purpose,
-          // TODO: 지금은 선택한 직무를 포함하고 있는 프로젝트 모두 노출이지만 인원이 다 차지 않은 프로젝트만 노출되도록 수정해야 함.
-          recruitMember: conditions.job
-            ? Raw((alias) => `JSON_EXTRACT(${alias}, :job) >= 1`, {
-                job: `$.${conditions.job}`,
-              })
-            : undefined,
           status: conditions.status,
         }),
       },
-      ...convertOptions(options),
-      ...getOrderOption(order),
     });
+  }
+
+  private getQuery(conditions: { stacks?: string[]; purpose?: PurposeType; job?: JobType; status?: StatusType }) {
+    const queryBuilder = this.getManager().createQueryBuilder(Project, 'project');
+    if (conditions.stacks) {
+      queryBuilder.andWhere(
+        new Brackets((qb) => {
+          conditions.stacks!.forEach((stack) => {
+            // NOTE: 직무끼리는 OR 연산
+            qb.orWhere(
+              new Brackets((qb) => {
+                qb.orWhere(`JSON_CONTAINS(project.stacks, '[${stack}]')`);
+              }),
+            );
+          });
+        }),
+      );
+    }
+
+    // TODO: 지금은 선택한 직무를 포함하고 있는 프로젝트 모두 노출이지만 인원이 다 차지 않은 프로젝트만 노출되도록 수정해야 함.
+    if (conditions.job) {
+      queryBuilder.andWhere(`JSON_EXTRACT(project.recruitMember,  '$.${conditions.job}') >= 1`);
+    }
+
+    const strippedConditions = {
+      ...stripUndefined({
+        purpose: conditions.purpose,
+        status: conditions.status,
+      }),
+    };
+
+    Object.entries(strippedConditions).map(([key, value]) =>
+      queryBuilder.andWhere(`${key} IN (:${key})`, { [key]: value }),
+    );
+    return queryBuilder;
   }
 }


### PR DESCRIPTION
### 개발사항
- stacks -> `simple-json` 으로 타입 변경
- 프로젝트 목록 -> 쿼리빌더를 사용하도록 변경
- Brackets 은 stacks 끼리는 or 연산, 그 외에는 and 연산으로 묶여야 되어서 사용했습니다.
  - 예시 쿼리 : stacks=1&stacks=4&job=designer -> `(stacks = 1 or stacks = 4) and job = designer`
